### PR TITLE
support for html`

### DIFF
--- a/syntaxes/es6-inline-html.json
+++ b/syntaxes/es6-inline-html.json
@@ -19,7 +19,7 @@
 	"patterns": [
 		{
 			"contentName": "meta.embedded.block.html",
-			"begin": "(\\s?\\/\\*\\s?(html|template|inline-html|inline-template)\\s?\\*\\/\\s?)(`)",
+			"begin": "(\\s?\\/?\\*?\\s?(html|template|inline-html|inline-template)\\s?\\*?\\/?\\s?)(`)",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.definition.comment.js"


### PR DESCRIPTION
I have some case to use [Tagged templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) like this

```js
import { html } from '@/vendor';

const template = html`
  <h1>hello world</h1>
`;
```

`html` is a help function for remove space from tags.
so I open this pr to support it.